### PR TITLE
feat: update README.md and remove test guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,20 @@ To run the program successfully, please check the following:
 Please set a `.env` file for the repo, you can run following instruction and fill information in terminal to set `.env`
 
 ```sh
-echo 'DISCORD_TOKEN=<your_discord_bot_token>
-TEST_GUILD_ID=<test_guild_id>' > .env
+echo 'DISCORD_TOKEN=<your_discord_bot_token>' > .env
 ```
 
 Build and start the containers:
 ```sh
-docker-compose up -d --build
+docker-compose up -d --build # For python version < 3.12
+docker compose up -d --build # For python version >= 3.12
 ```
 
 ## 💻 Local Development (without Docker)
 Please set a `.env` file for the repo, you can run following instruction and fill information in terminal to set `.env`
 
 ```sh
-echo 'DISCORD_TOKEN=<your_discord_bot_token>
-TEST_GUILD_ID=<test_guild_id>' > .env
+echo 'DISCORD_TOKEN=<your_discord_bot_token>' > .env
 ```
 
 Use **uv** to install dependencies the backend app need:

--- a/bot.py
+++ b/bot.py
@@ -27,8 +27,8 @@ async def main_loop():
     load_dotenv()
 
     dc_token = os.getenv("DISCORD_TOKEN")
-    test_guild_id = int(os.getenv("TEST_GUILD_ID"))
-    test_guild_obj = discord.Object(id=test_guild_id)
+    # test_guild_id = int(os.getenv("TEST_GUILD_ID"))
+    # test_guild_obj = discord.Object(id=test_guild_id)
 
     # bot settings
     intents = discord.Intents.all()
@@ -59,21 +59,21 @@ async def main_loop():
     @slash_is_owner()
     async def load(interaction: discord.Interaction, cog: str):
         await bot.load_extension(f"cogs.{cog}")
-        await bot.tree.sync(guild=test_guild_obj)
+        # await bot.tree.sync(guild=test_guild_obj)
         await interaction.response.send_message(f"[Info] 成功載入 \033[1m{cog}\033[0m")
 
     @bot.tree.command(name="unload", description="[管理員] 卸載特定功能模組")
     @slash_is_owner()
     async def unload(interaction: discord.Interaction, cog: str):
         await bot.unload_extension(f"cogs.{cog}")
-        await bot.tree.sync(guild=test_guild_obj)
+        # await bot.tree.sync(guild=test_guild_obj)
         await interaction.response.send_message(f"[Info] 成功卸載 \033[1m{cog}\033[0m")
 
     @bot.tree.command(name="reload", description="[管理員] 重新載入特定功能模組")
     @slash_is_owner()
     async def reload(interaction: discord.Interaction, cog: str):
         await bot.reload_extension(f"cogs.{cog}")
-        await bot.tree.sync(guild=test_guild_obj)
+        # await bot.tree.sync(guild=test_guild_obj)
         await interaction.response.send_message(f"[Info] 成功重新載入 \033[1m{cog}\033[0m")
 
     # Load cogs


### PR DESCRIPTION
This pull request removes the use of the `TEST_GUILD_ID` environment variable and related code for test guild synchronization, simplifying both the setup instructions and the bot's code. It also updates the Docker usage instructions in the `README.md` to clarify the correct command for different Python versions.

**Setup and Documentation Updates:**

* Updated the `.env` setup instructions in `README.md` to remove `TEST_GUILD_ID` and clarify that only `DISCORD_TOKEN` is required. Also, added guidance on using `docker compose` for Python >= 3.12 and `docker-compose` for earlier versions.

**Codebase Simplification:**

* Commented out all code in `bot.py` that references `TEST_GUILD_ID` and `test_guild_obj`, including guild-specific command synchronization after cog load/unload/reload. This means commands will now be synced globally rather than to a specific test guild. [[1]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L30-R31) [[2]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L62-R76)